### PR TITLE
refactor: remove legacy Model.query usage

### DIFF
--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -7,7 +7,7 @@ from core.providers.gemini import GeminiProvider
 from db import db
 from core.providers.models import ChatSession, ChatTurn
 from datetime import datetime, timezone
-from flask import g
+from flask import g, abort
 
 MODEL_PROVIDERS = {
     "deepseek": DeepSeekProvider(),
@@ -34,7 +34,9 @@ def summarize(
         chat_session = new_session.id
 
     # Update last_used time for current chat_session
-    session = ChatSession.query.get_or_404(chat_session)
+    session = db.session.get(ChatSession, chat_session)
+    if session is None:
+        abort(404)
     session.last_used = datetime.now(timezone.utc)
     db.session.commit()
 

--- a/core/providers/gemini.py
+++ b/core/providers/gemini.py
@@ -49,13 +49,11 @@ class GeminiProvider(LLMProvider):
             )
 
         # 1) Prior turns (oldest→newest), exclude current turn in SQL
-        prev_turns = (
-            ChatTurn.query
-            .filter(ChatTurn.session_id == chat_session,
-                    ChatTurn.id != chat_turn)
+        prev_turns = db.session.execute(
+            db.select(ChatTurn)
+            .filter(ChatTurn.session_id == chat_session, ChatTurn.id != chat_turn)
             .order_by(ChatTurn.created_at.asc(), ChatTurn.id.asc())
-            .all()
-        )
+        ).scalars().all()
         prev_turn_ids = [t.id for t in prev_turns]
         if not prev_turn_ids:
             prev_turn_ids = [-1]  # keep IN() valid but return 0 rows
@@ -63,12 +61,12 @@ class GeminiProvider(LLMProvider):
         # 2) Fetch the (single) gemini output per turn (no ORDER BY needed)
         outputs_by_turn = {
             o.turn_id: o
-            for o in (
-                LLMOutput.query
-                .filter(LLMOutput.turn_id.in_(prev_turn_ids),
-                        LLMOutput.provider == "gemini")
-                .all()
-            )
+            for o in db.session.execute(
+                db.select(LLMOutput).filter(
+                    LLMOutput.turn_id.in_(prev_turn_ids),
+                    LLMOutput.provider == "gemini",
+                )
+            ).scalars().all()
         }
 
         # 3) Build chat history


### PR DESCRIPTION
## Summary
- replace `Model.query` calls with `db.session` queries
- update routes and pipeline to rely on session-based lookups
- clean up provider implementations to use `db.select`

## Testing
- `pytest`
- `pyright` *(fails: No parameter named "turn_id", "provider", "summarizer_prompt", "content"; Import "alembic" could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68abb07c9524832d9b6f0655aeb219d6