### PR TITLE
fix: improve CORS handling and add health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Start the Flask server:
 flask --app app --debug run
 ```
 
+### CORS configuration
+
+When deploying the API you may need to allow requests from a separate
+frontend domain.  Set the `CORS_ALLOWED_ORIGINS` environment variable to a
+comma-separated list of allowed origins (for example, your Vercel URL).  If
+unset the server allows all origins which is convenient for local testing.
+
+The server also exposes a lightweight `GET /healthz` endpoint that Railway can
+use for liveness probes.
+
 ## 🧪 Example API Usage
 
 

--- a/auth.py
+++ b/auth.py
@@ -39,6 +39,12 @@ def _verify_supabase_jwt(token: str) -> dict:
 def auth_required(fn):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
+        # CORS preflight requests hit the endpoint with the OPTIONS method and
+        # without authorization headers.  Skip authentication so that browsers
+        # can complete the preflight successfully.
+        if request.method == "OPTIONS":
+            return ("", 204)
+
         auth = request.headers.get("Authorization", "")
         if not auth.startswith("Bearer "):
             abort(401)


### PR DESCRIPTION
## Summary
- allow configurable CORS origins via `CORS_ALLOWED_ORIGINS`
- skip auth on OPTIONS requests and expose simple `/healthz`
- document CORS settings and health probe endpoint

## Testing
- `python -m py_compile app.py auth.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1f581be58832d8b7ebdea441ae950